### PR TITLE
Use the correct header files for link collections

### DIFF
--- a/k4Reco/CaloDigi/src/RealisticCaloDigi.cc
+++ b/k4Reco/CaloDigi/src/RealisticCaloDigi.cc
@@ -2,7 +2,7 @@
 #include "RealisticCaloDigi.h"
 
 #include <edm4hep/MutableCalorimeterHit.h>
-#include <edm4hep/MutableCaloHitSimCaloHitLink.h>
+#include <edm4hep/CaloHitSimCaloHitLinkCollection.h>
 #include <edm4hep/CaloHitContribution.h>
 #include <CalorimeterHitType.h>
 

--- a/k4Reco/CaloDigi/src/RealisticCaloReco.cc
+++ b/k4Reco/CaloDigi/src/RealisticCaloReco.cc
@@ -4,7 +4,7 @@
 
 #include <edm4hep/SimCalorimeterHit.h>
 #include <edm4hep/MutableCalorimeterHit.h>
-#include <edm4hep/MutableCaloHitSimCaloHitLink.h>
+#include <edm4hep/CaloHitSimCaloHitLinkCollection.h>
 
 #include <iostream>
 #include <string>


### PR DESCRIPTION
The other headers are no longer generated since the switch to templated links in https://github.com/key4hep/EDM4hep/pull/373
