### PR TITLE
Fix overlay

### DIFF
--- a/k4Reco/Overlay/components/OverlayTiming.cpp
+++ b/k4Reco/Overlay/components/OverlayTiming.cpp
@@ -69,7 +69,7 @@ StatusCode OverlayTiming::initialize() {
   // TODO:: shuffle input files
   // std::shuffle(inputFiles.begin(), inputFiles.end(), rng_engine);
 
-  m_bkgEvents = make_unique<EventHolder>(inputFiles);
+  m_bkgEvents = make_unique<OverlayTimingNS::EventHolder>(inputFiles);
   for (auto& val : m_bkgEvents->m_totalNumberOfEvents) {
     if (val == 0) {
       std::string err = "No events found in the background files";

--- a/k4Reco/Overlay/components/OverlayTiming.h
+++ b/k4Reco/Overlay/components/OverlayTiming.h
@@ -53,28 +53,29 @@
 #include <string>
 #include <vector>
 
-struct EventHolder {
-  std::vector<std::vector<std::string>> m_fileNames;
-  std::vector<podio::Reader> m_rootFileReaders;
-  std::vector<size_t> m_totalNumberOfEvents;
-  std::map<int, podio::Frame> m_events;
+namespace OverlayTimingNS {
+  struct EventHolder {
+    std::vector<std::vector<std::string>> m_fileNames;
+    std::vector<podio::Reader> m_rootFileReaders;
+    std::vector<size_t> m_totalNumberOfEvents;
+    std::map<int, podio::Frame> m_events;
+    std::vector<size_t> m_nextEntry;
 
-  std::vector<size_t> m_nextEntry;
-
-  EventHolder(const std::vector<std::vector<std::string>>& fileNames) : m_fileNames(fileNames) {
-    for (auto& names : m_fileNames) {
-      m_rootFileReaders.emplace_back(podio::makeReader(names));
-      m_totalNumberOfEvents.push_back(m_rootFileReaders.back().getEntries("events"));
+    EventHolder(const std::vector<std::vector<std::string>>& fileNames) : m_fileNames(fileNames) {
+      for (auto& names : m_fileNames) {
+        m_rootFileReaders.emplace_back(podio::makeReader(names));
+        m_totalNumberOfEvents.push_back(m_rootFileReaders.back().getEntries("events"));
+      }
+      m_nextEntry.resize(m_fileNames.size(), 0);
     }
-    m_nextEntry.resize(m_fileNames.size(), 0);
-  }
-  EventHolder() = default;
+    EventHolder() = default;
 
-  // TODO: Cache functionality
-  // podio::Frame& read
+    // TODO: Cache functionality
+    // podio::Frame& read
 
-  size_t size() const { return m_fileNames.size(); }
-};
+    size_t size() const { return m_fileNames.size(); }
+  };
+}
 
 using retType =
     std::tuple<edm4hep::MCParticleCollection, std::vector<edm4hep::SimTrackerHitCollection>,
@@ -139,7 +140,7 @@ private:
 
   Gaudi::Property<float> m_deltaT{this, "Delta_t", float(0.5), "Time difference between BXs in the BXtrain"};
 
-  mutable std::unique_ptr<EventHolder> m_bkgEvents{};
+  mutable std::unique_ptr<OverlayTimingNS::EventHolder> m_bkgEvents{};
 
   Gaudi::Property<std::map<std::string, std::vector<float>>> m_timeWindows{
       this, "TimeWindows", std::map<std::string, std::vector<float>>(), "Time windows for the different collections"};

--- a/k4Reco/Overlay/components/OverlayTimingRandomMix.cpp
+++ b/k4Reco/Overlay/components/OverlayTimingRandomMix.cpp
@@ -91,7 +91,7 @@ StatusCode OverlayTimingRandomMix::initialize() {
     }
   }
 
-  m_bkgEvents = make_unique<EventHolder>(inputFiles);
+  m_bkgEvents = make_unique<OverlayTimingRandomMixNS::EventHolder>(inputFiles);
   for (auto& valset : m_bkgEvents->m_totalNumberOfEvents) {
     for (auto& val : valset) {
       if (val == 0) {

--- a/k4Reco/Overlay/components/OverlayTimingRandomMix.h
+++ b/k4Reco/Overlay/components/OverlayTimingRandomMix.h
@@ -53,34 +53,35 @@
 #include <string>
 #include <vector>
 
-struct EventHolder {
-  std::vector<std::vector<std::string>>   m_fileNames;
-  std::vector<std::vector<size_t>>        m_totalNumberOfEvents;
+namespace OverlayTimingRandomMixNS {
+  struct EventHolder {
+    std::vector<std::vector<std::string>>   m_fileNames;
+    std::vector<std::vector<size_t>>        m_totalNumberOfEvents;
+    std::vector<std::vector<size_t>> m_nextEntry;
 
-  std::vector<std::vector<size_t>> m_nextEntry;
+    EventHolder(const std::vector<std::vector<std::string>>& fileNames) : m_fileNames(fileNames) {
+      m_totalNumberOfEvents.resize(m_fileNames.size());
+      m_nextEntry.resize(m_fileNames.size());
 
-  EventHolder(const std::vector<std::vector<std::string>>& fileNames) : m_fileNames(fileNames) {
-    m_totalNumberOfEvents.resize(m_fileNames.size());
-    m_nextEntry.resize(m_fileNames.size());
-
-    for (int group = 0; group < m_fileNames.size(); group++) {
-      m_nextEntry[group].resize(m_fileNames[group].size());
-      for (auto& name : m_fileNames[group]) {
-        m_totalNumberOfEvents[group].push_back(1);//m_rootFileReaders[group].back().getEntries("events"));
+      for (int group = 0; group < m_fileNames.size(); group++) {
+        m_nextEntry[group].resize(m_fileNames[group].size());
+        for (auto& name : m_fileNames[group]) {
+          m_totalNumberOfEvents[group].push_back(1);//m_rootFileReaders[group].back().getEntries("events"));
+        }
       }
     }
-  }
-  EventHolder() = default;
+    EventHolder() = default;
 
-  podio::Reader open(int groupIndex, int index) {
-    return podio::makeReader(m_fileNames[groupIndex][index]);
-  }
+    podio::Reader open(int groupIndex, int index) {
+      return podio::makeReader(m_fileNames[groupIndex][index]);
+    }
 
-  // TODO: Cache functionality
-  // podio::Frame& read
+    // TODO: Cache functionality
+    // podio::Frame& read
 
-  size_t size() const { return m_fileNames.size(); }
-};
+    size_t size() const { return m_fileNames.size(); }
+  };
+}
 
 using retType =
     std::tuple<edm4hep::MCParticleCollection, std::vector<edm4hep::SimTrackerHitCollection>,
@@ -135,7 +136,7 @@ private:
 
   Gaudi::Property<float> m_deltaT{this, "Delta_t", float(0.5), "Time difference between BXs in the BXtrain"};
 
-  mutable std::unique_ptr<EventHolder> m_bkgEvents{};
+  mutable std::unique_ptr<OverlayTimingRandomMixNS::EventHolder> m_bkgEvents{};
 
   Gaudi::Property<std::map<std::string, std::vector<float>>> m_timeWindows{this, "TimeWindows", std::map<std::string, std::vector<float>>(), "Time windows for the different collections"};
   Gaudi::Property<bool> m_allowReusingBackgroundFiles{this, "AllowReusingBackgroundFiles", false, "If true the same background file can be used for the same event"};


### PR DESCRIPTION
There are two definitions of EventHolder in the k4Reco overlay that are slightly different. One is in [OverlayTiming.h](https://github.com/MuonColliderSoft/k4Reco/blob/main/k4Reco/Overlay/components/OverlayTiming.h#L64) and the other one is in [OverlayTimingRandomMix.h](https://github.com/MuonColliderSoft/k4Reco/blob/main/k4Reco/Overlay/components/OverlayTimingRandomMix.h#L56) . The EventHolder definition from OverlayTiming.h was getting picked up in OverlayTimingRandomMix.cpp which was causing issues. To fix it, I put the EventHolder definitions inside of unique namespaces. In the future we should probably harmonize those and put the definition in a single place.