### PR TITLE
GaudiTrkUtils::finaliseLCIOTrack and Refit Track-Truth Matching Fixes

### DIFF
--- a/k4Reco/ConformalTracking/src/GaudiTrkUtils.cpp
+++ b/k4Reco/ConformalTracking/src/GaudiTrkUtils.cpp
@@ -374,8 +374,7 @@ int GaudiTrkUtils::finaliseLCIOTrack(GaudiDDKalTestTrack& marlintrk, edm4hep::Mu
     // create a temporary IMarlinTrack
 
     // TODO
-    auto mTrk = std::make_shared<GaudiDDKalTestTrack>(m_thisAlg, const_cast<GaudiDDKalTest*>(&m_ddkaltest),
-                                                      marlintrk.m_edm4hep_hits_to_kaltest_hits);
+    auto mTrk = std::make_shared<GaudiDDKalTestTrack>(m_thisAlg, const_cast<GaudiDDKalTest*>(&m_ddkaltest));
     // mTrk->m_edm4hep_hits_to_kaltest_hits = ;
 
     edm4hep::TrackState ts;
@@ -383,22 +382,38 @@ int GaudiTrkUtils::finaliseLCIOTrack(GaudiDDKalTestTrack& marlintrk, edm4hep::Mu
     double chi2Tmp = 0;
     int ndfTmp = 0;
     return_error = marlintrk.getTrackState(last_constrained_hit, ts, chi2, ndf);
+    if (return_error != 0) {
+      m_thisAlg->debug() << "GaudiTrk::finaliseLCIOTrack: could not get TrackState at last constrained hit "
+                        << last_constrained_hit << endmsg;
+      return return_error;
+    }
 
     // m_thisAlg->debug()  << "  MarlinTrk::finaliseLCIOTrack:--  TrackState at last constrained hit : " << endmsg
     //   			<< toString( &ts )    << endmsg ;
 
     // need to add a dummy hit to the track
-    mTrk->addHit(last_constrained_hit);
-    mTrk->initialise(ts, fit_direction);
+    return_error = mTrk->addHit(last_constrained_hit);
+    if (return_error != 0) {
+      m_thisAlg->debug() << "MarlinTrk::finaliseLCIOTrack: could not add last constrained hit to temporary track "
+                        << last_constrained_hit << endmsg;
+      return return_error;
+    }
+    return_error = mTrk->initialise(ts, fit_direction);
+    if (return_error != 0) {
+      return return_error;
+    }
 
     auto hI = hits_in_fit.rbegin();
 
-    while ((*hI).first != last_constrained_hit) {
+    while (hI != hits_in_fit.rend() && (*hI).first != last_constrained_hit) {
       // m_thisAlg->debug()  << "  MarlinTrk::finaliseLCIOTrack:--  hit in reverse_iterator : "  << endmsg
       // 			  << toString( (*hI).first ) << endmsg ;
       ++hI;
     }
-
+    if (hI == hits_in_fit.rend()) {
+      m_thisAlg->error() << "MarlinTrk::finaliseLCIOTrack: last constrained hit not found in hits_in_fit" << endmsg;
+      return 1;
+    }
     ++hI;
 
     while (hI != hits_in_fit.rend()) {
@@ -417,6 +432,7 @@ int GaudiTrkUtils::finaliseLCIOTrack(GaudiDDKalTestTrack& marlintrk, edm4hep::Mu
       // TODO
       if (addHit != 0) {
         m_thisAlg->error() << " ****  MarlinTrk::finaliseLCIOTrack:  could not add inner hit to track !!! " << endmsg;
+        return addHit;
       }
 
       ++hI;

--- a/k4Reco/GaudiTrkUtils/src/GaudiDDKalTestTrack.cpp
+++ b/k4Reco/GaudiTrkUtils/src/GaudiDDKalTestTrack.cpp
@@ -40,10 +40,38 @@
 
 #include <Gaudi/Algorithm.h>
 
+#include <memory>
 #include <stdexcept>
 
 const int site_fails_chi2_cut = 3;
 const int no_intersection = 4;
+
+namespace {
+// Helper function to create a KalTest hit from an edm4hep TrackerHit and the corresponding measurement layer
+std::unique_ptr<DDVTrackHit> makeKalTestHit(const edm4hep::TrackerHit* trkhit, const DDVMeasLayer* ml) {
+  if (!trkhit || !ml) {
+    return nullptr;
+  }
+  if (!trkhit->isA<edm4hep::TrackerHitPlane>()) {
+    throw std::runtime_error(
+        "GaudiDDKalTestTrack - trkhit is not a TrackerHitPlane, this is not implemented yet");
+  }
+
+  auto hit = IMPL::TrackerHitPlaneImpl();
+  double pos[3] = {
+      trkhit->getPosition()[0],
+      trkhit->getPosition()[1],
+      trkhit->getPosition()[2]
+  };
+
+  hit.setPosition(pos);
+  hit.setCellID0(trkhit->getCellID());
+  hit.setdU(trkhit->as<edm4hep::TrackerHitPlane>().getDu());
+  hit.setdV(trkhit->as<edm4hep::TrackerHitPlane>().getDv());
+
+  return std::unique_ptr<DDVTrackHit>(ml->ConvertLCIOTrkHit(&hit));
+}
+} // namespace
 
 /** Helper class for defining a filter condition based on the delta chi2 in the AddAndFilter step.
  */
@@ -106,33 +134,14 @@ int GaudiDDKalTestTrack::addHit(const edm4hep::TrackerHit* trkhit, const DDVMeas
                      << " ml = " << ml << endmsg;
 
   if (trkhit && ml) {
-    // TODO: a LCIO hit has to be created because it's needed downstream
-    if (!trkhit->isA<edm4hep::TrackerHitPlane>()) {
-      throw std::runtime_error(
-          "GaudiDDKalTestTrack::addHit - trkhit is not a TrackerHitPlane, this is not implemented yet");
+    auto kalhit = makeKalTestHit(trkhit, ml);
+    if (!kalhit) {
+      m_thisAlg->warning() << " GaudiDDKalTestTrack::addHit - failed to create convert hit cellid "
+                           << trkhit->getCellID() << " on meas layer " << ml->GetName() << endmsg;
+      return 1;
     }
-    auto hit = IMPL::TrackerHitPlaneImpl();
-    double pos[3] = {trkhit->getPosition()[0], trkhit->getPosition()[1], trkhit->getPosition()[2]};
-    hit.setPosition(pos);
-    hit.setCellID0(trkhit->getCellID());
-    hit.setdU(trkhit->as<edm4hep::TrackerHitPlane>().getDu());
-    hit.setdV(trkhit->as<edm4hep::TrackerHitPlane>().getDv());
-
-    // Not needed
-    // hit.setCovMatrix(lcioCov);
-    // static_cast<IMPL::TrackerHitImpl*>(static_cast<EVENT::TrackerHit*>(hit))->setCovMatrix(lcioCov);
-    // hit.setQuality(trkhit->getQuality());
-    // hit.setType(trkhit->getType());
-    // hit.setEDep(trkhit->getEDep());
-    // hit.setEDepError(trkhit->getEDepError());
-    // float u[2] = {trkhit->getU()[0], trkhit->getU()[1]};
-    // hit.setU(u);
-    // float v[2] = {trkhit->getV()[0], trkhit->getV()[1]};
-    // hit.setV(v);
-    // hit.setTime(trkhit->getTime());
-
-    auto* kalhit = ml->ConvertLCIOTrkHit(&hit);
-    return this->addHit(trkhit, kalhit, ml);
+    
+    return this->addHit(trkhit, kalhit.release(), ml);
   } else {
     m_thisAlg->warning() << " GaudiDDKalTestTrack::addHit - bad inputs " << trkhit << " ml : " << ml << endmsg;
     return 1;
@@ -352,11 +361,22 @@ int GaudiDDKalTestTrack::addAndFit(DDVTrackHit* kalhit, double& chi2increment, T
   m_thisAlg->debug() << "GaudiDDKalTestTrack::addAndFit called : maxChi2Increment = " << std::scientific
                      << maxChi2Increment << endmsg;
 
+  site = nullptr;
+  chi2increment = DBL_MAX;
+
   if (!m_initialised) {
     throw std::runtime_error("Track fit not initialised");
   }
+  if (!kalhit) {
+    m_thisAlg->warning() << "GaudiDDKalTestTrack::addAndFit called with null kalhit pointer " << endmsg;
+    return 1;
+  }
 
   const auto* ml = dynamic_cast<const DDVMeasLayer*>(&(kalhit->GetMeasLayer()));
+  if (!ml) {
+    m_thisAlg->warning() << "GaudiDDKalTestTrack::addAndFit - failed to find measurement layer for hit " << endmsg;
+    return 1;
+  }
 
   if (m_thisAlg->msgLevel(MSG::DEBUG)) {
     m_thisAlg->debug() << "Kaltrack::addAndFit :  add site to track at index : " << ml->GetIndex() << " for type "
@@ -432,17 +452,18 @@ int GaudiDDKalTestTrack::addAndFit(const edm4hep::TrackerHit* trkhit, double& ch
     return 1;
   }
 
-  auto* kalhit = (*m_edm4hep_hits_to_kaltest_hits)[trkhit];
+  // Here we need to create a fresh KalTest hit owned by THIS track
+  std::unique_ptr<DDVTrackHit> kalhit = makeKalTestHit(trkhit, ml);
 
   if (!kalhit) { // fg: ml->ConvertLCIOTrkHit returns 0 if hit not on surface !!!
     return 1;
   }
 
   TKalTrackSite* site = nullptr;
-  int error_code = this->addAndFit(kalhit, chi2increment, site, maxChi2Increment);
+  DDVTrackHit* kalhitRaw = kalhit.get();
+  int error_code = this->addAndFit(kalhitRaw, chi2increment, site, maxChi2Increment);
 
   if (error_code != 0) {
-    delete kalhit;
 
     // if the hit fails for any reason other than the Chi2 cut record the Chi2 contibution as DBL_MAX
     if (error_code != site_fails_chi2_cut) {
@@ -450,15 +471,20 @@ int GaudiDDKalTestTrack::addAndFit(const edm4hep::TrackerHit* trkhit, double& ch
     }
 
     m_outlier_chi2_values.push_back(std::make_pair(trkhit, chi2increment));
+    m_hit_not_used_for_sites.push_back(trkhit);
 
     m_thisAlg->debug() << ">>>>>>>>>>>  addAndFit Number of Outliers : " << m_outlier_chi2_values.size() << endmsg;
 
     return error_code;
-  } else {
-    this->addHit(trkhit, kalhit, ml);
-    m_hit_used_for_sites[trkhit] = site;
-    m_hit_chi2_values.push_back(std::make_pair(trkhit, chi2increment));
   }
+
+  const int addHitError = this->addHit(trkhit, kalhit.release(), ml);
+  if (addHitError != 0) {
+    return addHitError;
+  }
+
+  m_hit_used_for_sites[trkhit] = site;
+  m_hit_chi2_values.push_back(std::make_pair(trkhit, chi2increment));
 
   // set the values for the point at which the fit becomes constained
   if (!m_trackHitAtPositiveNDF && m_kaltrack->GetNDF() >= 0) {

--- a/k4Reco/Tracking/src/RefitFinal.cpp
+++ b/k4Reco/Tracking/src/RefitFinal.cpp
@@ -209,10 +209,10 @@ std::tuple<edm4hep::TrackCollection, edm4hep::TrackMCParticleLinkCollection> Ref
     }
 
     // create the Track-MCParticle relation
-    if (trackIndexToMCParticle.find(static_cast<int>(iTrack)) != trackIndexToMCParticle.end()) {
+    if (trackIndexToMCParticle.find(static_cast<int>(track.getObjectID().index)) != trackIndexToMCParticle.end()) {
       edm4hep::MutableTrackMCParticleLink relation = trackRelationCollection.create();
       relation.setFrom(edm4hep_trk);
-      relation.setTo(trackIndexToMCParticle.at(static_cast<int>(iTrack)));
+      relation.setTo(trackIndexToMCParticle.at(static_cast<int>(track.getObjectID().index)));
     }
   } // for loop to the tracks
 


### PR DESCRIPTION
This PR fixes a crash that occurs when a [hit is tossed out](https://github.com/MuonColliderSoft/k4Reco/blob/main/k4Reco/GaudiTrkUtils/src/GaudiDDKalTestTrack.cpp#L387) within the GaudiDDKalTestTrack::addAndFit function called within GaudiTrkUtils::finaliseLCIOTrack within RefitFinal.cpp. This deletes a `kalhit` [here](https://github.com/MuonColliderSoft/k4Reco/blob/main/k4Reco/GaudiTrkUtils/src/GaudiDDKalTestTrack.cpp#L148) within the GaudiTrk, however, are still within the `m_kalhits` vector that are added [here](m_kalhits), causing a segmentation violation.

Separately, this PR also fixes an issue with track-truth matching for refitted tracks caused by a mismatch between using `iTrack` vs. `track.getObjectID().index` within the `trackIndexToMCParticle` map that is made first using `trk.getObjectID().index` [here ](https://github.com/MuonColliderSoft/k4Reco/blob/main/k4Reco/Tracking/src/RefitFinal.cpp#L86) and later accessed with `iTrack` on [these lines](https://github.com/MuonColliderSoft/k4Reco/blob/main/k4Reco/Tracking/src/RefitFinal.cpp#L212-L215). This fix resulted in an improvement in tracking efficiency from 53% -> 88% for refitted tracks with a muon gun, derived using the track-truth particle matching. 


These fixes were written by @samf25 and I tested this with the [mucoll-sim-ubuntu24 main image](https://github.com/MuonColliderSoft/mucoll-spack/pkgs/container/mucoll-sim-ubuntu24/872376245?tag=main), built on April 28th 2026, and the `main` branch of MuonColliderSoft/k4Reco. 