### PR TITLE
Split the propagation-time correction into independent hit-time and time-window flags

### DIFF
--- a/k4Reco/DDPlanarDigi/components/DDPlanarDigi.cpp
+++ b/k4Reco/DDPlanarDigi/components/DDPlanarDigi.cpp
@@ -176,25 +176,29 @@ DDPlanarDigi::operator()(const edm4hep::SimTrackerHitCollection& simTrackerHits,
               << " ns according to resolution: " << resT << " ns" << endmsg;
     }
 
+    // Skip the hit if its time is outside the acceptance time window
+    if (m_useTimeWindow) {
+      // TODO: Check that the length of the time window is OK
+      float timeWindow_min = m_timeWindowMin.size() > 1 ? m_timeWindowMin[layer] : m_timeWindowMin[0];
+      float timeWindow_max = m_timeWindowMax.size() > 1 ? m_timeWindowMax[layer] : m_timeWindowMax[0];
+      double windowT = hitT;
+      if (m_correctTimeWindowForPropagation) {
+        windowT -= oldPos.r() / (TMath::C() / 1e6);
+      }
+      if (windowT < timeWindow_min || windowT > timeWindow_max) {
+        debug() << "hit at T: " << hit.getTime() << " smeared to: " << windowT
+                << " is outside the time window: hit dropped" << endmsg;
+        ++nDismissedHits;
+        continue;
+      }
+    }
+
     // Correcting for the propagation time
     if (m_correctTimesForPropagation) {
       double dt = oldPos.r() / (TMath::C() / 1e6);
       hitT -= dt;
       debug() << "corrected hit at R: " << oldPos.r() << " mm by propagation time: " << dt << " ns to T: " << hitT
               << " ns" << endmsg;
-    }
-
-    // Skip the hit if its time is outside the acceptance time window
-    if (m_useTimeWindow) {
-      // TODO: Check that the length of the time window is OK
-      float timeWindow_min = m_timeWindowMin.size() > 1 ? m_timeWindowMin[layer] : m_timeWindowMin[0];
-      float timeWindow_max = m_timeWindowMax.size() > 1 ? m_timeWindowMax[layer] : m_timeWindowMax[0];
-      if (hitT < timeWindow_min || hitT > timeWindow_max) {
-        debug() << "hit at T: " << hit.getTime() << " smeared to: " << hitT
-                << " is outside the time window: hit dropped" << endmsg;
-        ++nDismissedHits;
-        continue;
-      }
     }
 
     // Try to smear the hit position but ensure the hit is inside the sensitive region

--- a/k4Reco/DDPlanarDigi/components/DDPlanarDigi.h
+++ b/k4Reco/DDPlanarDigi/components/DDPlanarDigi.h
@@ -114,7 +114,10 @@ private:
       "Only accept hits with time (after smearing) within the specified time window (default: false)"};
   Gaudi::Property<bool> m_correctTimesForPropagation{
       this, "CorrectTimesForPropagation", false,
-      "Correct hit time for the propagation: radial distance/c (default: false)"};
+      "Correct the stored hit time for the propagation time-of-flight: radial distance/c (default: false)"};
+  Gaudi::Property<bool> m_correctTimeWindowForPropagation{
+      this, "CorrectTimeWindowForPropagation", true,
+      "Correct the hit time for the propagation time-of-flight when applying the time window cut (default: true)"};
   Gaudi::Property<std::vector<float>> m_timeWindowMin{
       this, "TimeWindowMin", {-1e9}, "Minimum time (ns) of SimTrackerHit to be digitized"};
   Gaudi::Property<std::vector<float>> m_timeWindowMax{


### PR DESCRIPTION
`DDPlanarDigi` had a single `CorrectTimesForPropagation` flag that subtracted the
propagation time-of-flight (radial distance/c) from the hit time *before* the time
window cut. This coupled two independent choices: whether the time window is defined
relative to the expected arrival time, and whether the stored hit times are
TOF-corrected. In particular, it was impossible to apply the usual TOF-corrected time
window while keeping absolute hit times in the output — which is needed when the
downstream tracking wants to use the physical hit time (e.g. time-aware seeding and
4D track finding).

This PR changes the old behavior of `CorrectTimesForPropagation` and adds an additional flag:

- **`CorrectTimesForPropagation`** — subtract the propagation TOF from the
  stored (digitized) hit time
- **`CorrectTimeWindowForPropagation`** — subtract the propagation TOF from the hit
  time only when applying the time window cut, leaving the stored time untouched

Setting both reproduces the old `CorrectTimesForPropagation=True` behaviour.

@madbaron